### PR TITLE
Clean up wrapping Try inside MonadError

### DIFF
--- a/sqs/src/main/scala/sqs4s/Connection.scala
+++ b/sqs/src/main/scala/sqs4s/Connection.scala
@@ -1,12 +1,9 @@
 package sqs4s
 
-import cats.MonadError
 import cats.effect._
 import com.amazon.sqs.javamessaging._
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import javax.jms.Session
-
-import scala.util.Try
 
 private[sqs4s] trait Connection {
 
@@ -14,39 +11,23 @@ private[sqs4s] trait Connection {
     client: AmazonSQSAsync
   ): Resource[F, SQSConnection] =
     Resource.make[F, SQSConnection] {
-      val sqsConn = Try {
+      Sync[F].delay {
         val connFactory =
           new SQSConnectionFactory(new ProviderConfiguration(), client)
-        val conn = connFactory.createConnection()
-        conn
+        connFactory.createConnection()
       }
-      MonadError[F, Throwable].fromTry(sqsConn)
-    } { sqsConn =>
-      Sync[F].defer(MonadError[F, Throwable].fromTry(Try(sqsConn.close())))
-    }
+    }(sqsConn => Sync[F].delay(sqsConn.close()))
 
   def session[F[_]: Sync](
     acknowledgeMode: Int
   ): SQSConnection => Resource[F, Session] =
     conn =>
       Resource.make[F, Session](
-        MonadError[F, Throwable]
-          .fromTry(Try(conn.createSession(false, acknowledgeMode)))
-      )(
-        sess =>
-          Sync[F].defer(
-            MonadError[F, Throwable]
-              .fromTry(Try(sess.close()))
-          )
-      )
+        Sync[F].delay(conn.createSession(false, acknowledgeMode))
+      )(sess => Sync[F].delay(sess.close()))
 
   def queue[F[_]: Sync](
     queueName: String
   ): Session => Resource[F, javax.jms.Queue] =
-    sess =>
-      Resource.liftF(
-        Sync[F].defer(
-          MonadError[F, Throwable].fromTry(Try(sess.createQueue(queueName)))
-        )
-      )
+    sess => Resource.liftF(Sync[F].delay(sess.createQueue(queueName)))
 }


### PR DESCRIPTION
Async effect already handle error, hence, no need to wrap calls inside Try anymore. Also, correctly suspend side effects with Async delay since Try still run code.