### PR TITLE
Various changes around DeleteMessageBatch

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -49,11 +49,37 @@ Where `F` is `F[_]: MonadError[?[_], Throwable]` to encapsulate error.
 
 #### High Level
 
-- `produce` produce a message to SQS
-- `batchProduce` produce messages to SQS in batch operation
-- `consume` consume messages from SQS as a fs2 Stream, only acknowledge the message only when it has been processed
-- `consumeAsync` consume messages but making multiple calls to SQS in parallel
-- `dequeue` get messages from SQS as a fs2 Stream but acknowledge right away
-- `dequeueAsync` get messages but making multiple calls to SQS in parallel
-- `peek` peek for X number of messages in SQS without acknowledging them
+##### produce 
+
+Produce a message to SQS
+
+##### batchProduce
+
+Produce messages to SQS in batch operation
+
+##### consume
+
+Consume messages from SQS as a fs2 Stream, only acknowledge the message only 
+when it has been processed
+
+##### consumeAsync
+
+Consume messages but making multiple calls to SQS in parallel
+
+##### dequeue
+ 
+Get messages from SQS as a fs2 Stream but acknowledge right away
+
+##### dequeueAsync
+
+Get messages but making multiple calls to SQS in parallel. This takes a `process`
+function of `T => F[Unit]` to represent processing a message in a queue. Please 
+note that this does not work for FIFO queue because internally, the client pulls
+multiple messages from SQS in parallel, run the `process` process function on 
+each message and finally, acknowledge messages in batch.
+
+##### peek
+
+Peek for X number of messages in SQS without acknowledging them, as a result,
+the messages stay in the queue.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -44,11 +44,7 @@ val clientSrc = BlazeClientBuilder[IO](ec)
 
 val consumed = for {
   client <- Stream.resource(clientSrc)
-  cred <- Stream.resource(Credential.instanceMetadataResource(
-    client,
-    6.hours,
-    5.minutes
-  ))
+  cred <- Stream.resource(Credentials.chain(client))
   producer = SqsProducer[TestMessage](
     client,
     SqsConfig(queue, cred, region)
@@ -68,82 +64,6 @@ val consumed = for {
 } yield result
 ```
 
-## Pub/Sub
+## More
 
-```scala
-import java.time.Instant
-
-import cats.implicits._
-import cats.effect.{ExitCode, IO, IOApp, Sync}
-import org.http4s.Uri
-import sqs4s.api.{AwsAuth, ConsumerSettings, SqsSettings}
-import sqs4s.serialization.{SqsDeserializer, SqsSerializer}
-import fs2._
-import org.http4s.client.blaze.BlazeClientBuilder
-import sqs4s.api.hi.{SqsConsumer, SqsProducer}
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-
-object Main extends IOApp {
-
-  case class Event(
-    ts: Long
-  )
-
-  object Event {
-    implicit def deserializer[F[_]: Sync]: SqsDeserializer[F, Event] = new SqsDeserializer[F, Event] {
-      override def deserialize(s: String): F[Event] = Event(s.toLong).pure[F]
-    }
-
-    implicit val serializer: SqsSerializer[Event] = (t: Event) => t.ts.toString
-  }
-
-  override def run(args: List[String]): IO[ExitCode] = {
-    val accessKey = sys.env("ACCESS_KEY")
-    val secretKey = sys.env("SECRET_KEY")
-    val awsAccountId = sys.env("AWS_ACCOUNT_ID")
-    val queue = Uri.unsafeFromString(s"https://sqs.eu-west-1.amazonaws.com/$awsAccountId/test")
-    val settings = SqsSettings(queue, AwsAuth(accessKey, secretKey, "eu-west-1"))
-    val consumerSettings = ConsumerSettings(
-      queue = settings.queue,
-      auth = settings.auth,
-      waitTimeSeconds = Some(1),
-      pollingRate = 2.seconds
-    )
-
-    val clientResource = BlazeClientBuilder[IO](ExecutionContext.global)
-      .withMaxTotalConnections(256)
-      .withMaxWaitQueueLimit(2048)
-      .withMaxConnectionsPerRequestKey(Function.const(2048))
-      .resource
-
-    val producerResource = clientResource.map { client =>
-      SqsProducer[Event](client, settings)
-    }
-
-    val producingStream = Stream.resource(producerResource).flatMap { producer =>
-      Stream
-        .repeatEval(IO(Instant.now().toEpochMilli))
-        .metered(1.second)
-        .map(Event.apply)
-        .evalMap(e => producer.produce(e) >> IO(println("++ Produced: " + e)))
-    }
-
-    val consumerResource = clientResource.map { client =>
-      SqsConsumer[Event](client, consumerSettings)
-    }
-
-    val consumingStream = Stream.resource(consumerResource).flatMap { consumer =>
-      consumer.consumeAsync(128) { consumed =>
-        IO(println("-- Consumed: " + consumed))
-      }
-    }
-
-    Stream(
-      producingStream,
-      consumingStream
-    ).parJoinUnbounded.compile.drain.as(ExitCode.Success)
-  }
-}
-```
+More examples can be found in `ClientItSpec.scala`

--- a/native/src/it/scala/sqs4s/api/hi/ClientItSpec.scala
+++ b/native/src/it/scala/sqs4s/api/hi/ClientItSpec.scala
@@ -1,6 +1,7 @@
 package sqs4s.api.hi
 
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import cats.effect.concurrent.Ref
@@ -8,16 +9,13 @@ import cats.effect.{Clock, IO, Resource}
 import cats.implicits._
 import fs2.Stream
 import fs2.concurrent.SignallingRef
-import io.circe.generic.semiauto._
-import io.circe.syntax._
-import io.circe.{parser, _}
 import org.http4s.Uri
+import org.http4s.client.Client
 import org.http4s.client.blaze.BlazeClientBuilder
-import org.scalacheck.{Arbitrary, Gen}
 import sqs4s.IOSpec
-import sqs4s.api._
+import sqs4s.api.lo.{CreateQueue, DeleteMessageBatch, DeleteQueue}
+import sqs4s.api.{SqsConfig, _}
 import sqs4s.auth.Credentials
-import sqs4s.serialization.{SqsDeserializer, SqsSerializer}
 
 import scala.concurrent.duration._
 
@@ -32,87 +30,73 @@ class ClientItSpec extends IOSpec {
   }
 
   val awsAccountId = sys.env("AWS_ACCOUNT_ID")
-  val queue = Uri.unsafeFromString(
-    s"https://sqs.eu-west-1.amazonaws.com/$awsAccountId/test"
-  )
+  val sqsRootEndpoint =
+    Uri.unsafeFromString("https://sqs.eu-west-1.amazonaws.com/")
   val region = "eu-west-1"
-
-  case class TestMessage(string: String, int: Int, boolean: Boolean)
-
-  object TestMessage {
-    implicit val encode: Encoder[TestMessage] = deriveEncoder
-    implicit val decode: Decoder[TestMessage] = deriveDecoder
-
-    implicit val desrlz = new SqsDeserializer[IO, TestMessage] {
-      override def deserialize(u: String): IO[TestMessage] =
-        IO.fromEither(parser.decode[TestMessage](u))
-    }
-
-    implicit val srlz = new SqsSerializer[TestMessage] {
-      override def serialize(t: TestMessage): String =
-        t.asJson.noSpaces
-    }
-
-    implicit val arbTestMessage: Arbitrary[TestMessage] = {
-      val gen = for {
-        str <- Gen.alphaNumStr
-        int <- Gen.choose(Int.MinValue, Int.MaxValue)
-        bool <- Gen.oneOf(Seq(true, false))
-      } yield TestMessage(str, int, bool)
-      Arbitrary(gen)
-    }
-
-    def arbStream(n: Long): Stream[IO, TestMessage] = {
-      val msg = arb[TestMessage]
-      Stream
-        .random[IO]
-        .map(i => msg.copy(int = i))
-        .take(n)
-    }
-  }
 
   behavior.of("SQS Consumer and Producer")
 
-  trait Fixture {
-    val clientResrc = BlazeClientBuilder[IO](ec)
-      .withMaxTotalConnections(256)
-      .withMaxWaitQueueLimit(2048)
-      .withMaxConnectionsPerRequestKey(Function.const(2048))
-      .resource
+  val clientResource = BlazeClientBuilder[IO](ec)
+    .withMaxTotalConnections(256)
+    .withMaxWaitQueueLimit(2048)
+    .withMaxConnectionsPerRequestKey(Function.const(2048))
+    .resource
+
+  def queueResource(
+    client: Client[IO],
+    cred: Credentials[IO]
+  ): Resource[IO, CreateQueue.Result] = {
+    val config = SqsConfig(sqsRootEndpoint, cred, region)
+    Resource.make {
+      IO.delay("test-" + UUID.randomUUID()).flatMap { name =>
+        CreateQueue[IO](name, sqsRootEndpoint).runWith(client, config)
+      }
+    } { queue =>
+      DeleteQueue[IO](Uri.unsafeFromString(queue.queueUrl)).runWith(
+        client,
+        config
+      ).void
+    }
   }
 
-  it should "batch produce messages" in new Fixture {
+  val producerConsumerResource =
+    for {
+      client <- clientResource
+      cred <- Credentials.chain(client)
+      consumerProducer <- queueResource(client, cred).map { queue =>
+        val uri = Uri.unsafeFromString(queue.queueUrl)
+        val conf = SqsConfig(uri, cred, region)
+        val producer = SqsProducer[TestMessage](client, conf)
+        val consumer = SqsConsumer[TestMessage](
+          client,
+          ConsumerConfig(
+            conf.queue,
+            conf.credentials,
+            conf.region,
+            waitTimeSeconds = Some(1),
+            pollingRate = 2.seconds
+          )
+        )
+        (producer, consumer)
+      }
+    } yield consumerProducer
+
+  it should "batchProduce dequeueAsync messages" in {
     val numOfMsgs = 22L
     val input = TestMessage.arbStream(numOfMsgs)
 
-    val result = for {
-      client <- Stream.resource(clientResrc)
-      cred <- Stream.resource(Credentials.chain[IO](client))
-      producer = SqsProducer[TestMessage](
-        client,
-        SqsConfig(queue, cred, region)
-      )
-      consumer = SqsConsumer[TestMessage](
-        client,
-        ConsumerConfig(
-          queue,
-          cred,
-          region,
-          waitTimeSeconds = Some(1),
-          pollingRate = 2.seconds
-        )
-      )
-      _ <- producer
-        .batchProduce(input, _.int.toString.pure[IO])
-      output <- consumer.dequeueAsync(256)
-    } yield output
+    val dequeueAsync =
+      producerConsumerResource.use {
+        case (producer, consumer) =>
+          producer
+            .batchProduce(input, _.int.toString.pure[IO]).compile.drain >>
+            consumer.dequeueAsync(256).take(numOfMsgs).compile.toList
+      }
 
-    result.take(
-      numOfMsgs
-    ).compile.toList.unsafeRunSync().size shouldBe numOfMsgs
+    dequeueAsync.unsafeRunSync().size shouldBe numOfMsgs
   }
 
-  it should "batch consume messages" in new Fixture {
+  it should "batchProduce consumeAsync messages" in {
     val numOfMsgs = 22L
     val input = TestMessage.arbStream(numOfMsgs).compile.toList.unsafeRunSync()
     val inputStream = Stream[IO, TestMessage](input: _*)
@@ -122,87 +106,126 @@ class ClientItSpec extends IOSpec {
     val resources = for {
       r <- ref
       interrupter <- Resource.liftF(SignallingRef[IO, Boolean](false))
-      client <- clientResrc
-      cred <- Credentials.chain[IO](client)
-    } yield (r, interrupter, client, cred)
+      producerConsumer <- producerConsumerResource
+    } yield (r, interrupter, producerConsumer._1, producerConsumer._2)
 
-    val outputF = resources.use {
-      case (ref, interrupter, client, cred) =>
-        val producer =
-          SqsProducer[TestMessage](client, SqsConfig(queue, cred, region))
-        val consumer = SqsConsumer[TestMessage](
-          client,
-          ConsumerConfig(
-            queue,
-            cred,
-            region,
-            waitTimeSeconds = Some(1),
-            pollingRate = 2.seconds
-          )
-        )
+    val consumeAsync = resources.use {
+      case (ref, interrupter, producer, consumer) =>
         producer
           .batchProduce(inputStream, _.int.toString.pure[IO])
           .compile
-          .drain
-          .flatMap { _ =>
-            consumer
-              .consumeAsync(256)(msg => {
-                def loop(): IO[Unit] = {
-                  ref.access.flatMap {
-                    case (list, setter) =>
-                      val set = setter(list :+ msg).flatMap { updated =>
-                        if (updated) {
-                          ().pure[IO]
-                        } else {
-                          loop()
-                        }
+          .drain >>
+          consumer
+            .consumeAsync(256)(msg => {
+              def loop(): IO[Unit] = {
+                ref.access.flatMap {
+                  case (list, setter) =>
+                    val set = setter(list :+ msg).flatMap { updated =>
+                      if (updated) {
+                        ().pure[IO]
+                      } else {
+                        loop()
                       }
-                      if (list.size == numOfMsgs - 1)
-                        set >> interrupter.set(true)
-                      else set
-                  }
+                    }
+                    if (list.size == numOfMsgs - 1)
+                      set >> interrupter.set(true)
+                    else set
                 }
-                loop()
-              })
-              .interruptWhen(interrupter)
-              .compile
-              .drain
-          } >> ref.get
+              }
+              loop()
+            })
+            .interruptWhen(interrupter)
+            .compile
+            .drain >> ref.get
     }
 
-    outputF
+    consumeAsync
       .unsafeRunSync() should contain theSameElementsAs input
   }
 
-  it should "produce and dequeue messages" in new Fixture {
+  it should "produce and dequeueAsync messages" in {
     val numOfMsgs = 22L
     val input = TestMessage.arbStream(numOfMsgs).compile.toList.unsafeRunSync()
     val inputStream = Stream[IO, TestMessage](input: _*)
 
-    val consumed = for {
-      client <- Stream.resource(clientResrc)
-      cred <- Stream.resource(Credentials.chain[IO](client))
-      producer = SqsProducer[TestMessage](
-        client,
-        SqsConfig(queue, cred, region)
-      )
-      consumer = SqsConsumer[TestMessage](
-        client,
-        ConsumerConfig(
-          queue,
-          cred,
-          region,
-          waitTimeSeconds = Some(1),
-          pollingRate = 2.seconds
-        )
-      )
-      _ <- inputStream
-        .mapAsync(256)(msg => producer.produce(msg))
-      result <- consumer.dequeueAsync(256)
-    } yield result
+    val dequeueAsync =
+      producerConsumerResource.use {
+        case (producer, consumer) =>
+          inputStream.mapAsync(256)(producer.produce(_)).compile.drain >>
+            consumer.dequeueAsync(256).take(numOfMsgs).compile.toList
+      }
 
-    consumed.take(
-      numOfMsgs
-    ).compile.toList.unsafeRunSync() should contain theSameElementsAs input
+    dequeueAsync.unsafeRunSync() should contain theSameElementsAs input
+  }
+
+  it should "produce, readsAsync and ack messages" in {
+    val numOfMsgs = 22L
+    val input = TestMessage.arbStream(numOfMsgs).compile.toList.unsafeRunSync()
+    val inputStream = Stream[IO, TestMessage](input: _*)
+
+    def reads(ref: Ref[IO, List[TestMessage]]) =
+      producerConsumerResource.use {
+        case (producer, consumer) =>
+          inputStream.mapAsync(256)(producer.produce(_)).compile.drain >>
+            consumer.readsAsync(256).evalTap(
+              msg => ref.update(_ :+ msg.body)
+            ).map(_.receiptHandle).through(
+              consumer.ack
+            ).take(numOfMsgs).compile.drain >> ref.get
+      }
+
+    Ref.of[IO, List[TestMessage]](List.empty).flatMap(
+      reads
+    ).unsafeRunSync() should contain theSameElementsAs input
+  }
+
+  it should "produce, reads and batchAck messages" in {
+    val numOfMsgs = 22L
+    val input = TestMessage.arbStream(numOfMsgs).compile.toList.unsafeRunSync()
+    val inputStream = Stream[IO, TestMessage](input: _*)
+
+    val resources = for {
+      ref <- Resource.liftF(Ref.of[IO, List[TestMessage]](List.empty))
+      interrupter <- Resource.liftF(SignallingRef[IO, Boolean](false))
+      producerConsumer <- producerConsumerResource
+    } yield (ref, interrupter, producerConsumer._1, producerConsumer._2)
+
+    val batchAck = resources.use {
+      case (ref, interrupter, producer, consumer) =>
+        inputStream.mapAsync(256)(producer.produce(_)).compile.drain >>
+          consumer.reads.evalTap { msg =>
+
+            def loop(): IO[Unit] = {
+              ref.access.flatMap {
+                case (list, setter) =>
+                  if (list.contains(msg)) {
+                    ().pure[IO]
+                  } else {
+                    val set = setter(list :+ msg.body).flatMap {
+                      case true =>
+                        ().pure[IO]
+                      case false =>
+                        loop()
+                    }
+                    if (list.size == numOfMsgs - 1)
+                      set >> interrupter.set(true)
+                    else set
+                  }
+              }
+            }
+            loop()
+          }.map { msg =>
+            DeleteMessageBatch.Entry(
+              msg.messageId,
+              msg.receiptHandle
+            )
+          }.through(
+            consumer.batchAck(256)
+          ).interruptWhen(interrupter)
+            .compile
+            .drain >> ref.get
+    }
+
+    batchAck.unsafeRunSync() should contain theSameElementsAs input
   }
 }

--- a/native/src/it/scala/sqs4s/api/hi/models.scala
+++ b/native/src/it/scala/sqs4s/api/hi/models.scala
@@ -1,0 +1,43 @@
+package sqs4s.api.hi
+
+import cats.effect.IO
+import fs2.Stream
+import io.circe.generic.semiauto._
+import io.circe.syntax._
+import io.circe.{parser, _}
+import org.scalacheck.{Arbitrary, Gen}
+import sqs4s.serialization.{SqsDeserializer, SqsSerializer}
+
+case class TestMessage(string: String, int: Int, boolean: Boolean)
+
+object TestMessage {
+  implicit val encode: Encoder[TestMessage] = deriveEncoder
+  implicit val decode: Decoder[TestMessage] = deriveDecoder
+
+  implicit val desrlz = new SqsDeserializer[IO, TestMessage] {
+    override def deserialize(u: String): IO[TestMessage] =
+      IO.fromEither(parser.decode[TestMessage](u))
+  }
+
+  implicit val srlz = new SqsSerializer[TestMessage] {
+    override def serialize(t: TestMessage): String =
+      t.asJson.noSpaces
+  }
+
+  implicit val arbTestMessage: Arbitrary[TestMessage] = {
+    val gen = for {
+      str <- Gen.alphaNumStr
+      int <- Gen.choose(Int.MinValue, Int.MaxValue)
+      bool <- Gen.oneOf(Seq(true, false))
+    } yield TestMessage(str, int, bool)
+    Arbitrary(gen)
+  }
+
+  def arbStream(n: Long): Stream[IO, TestMessage] = {
+    val msg = arbTestMessage.arbitrary.sample.get
+    Stream
+      .random[IO]
+      .map(i => msg.copy(int = i))
+      .take(n)
+  }
+}

--- a/native/src/it/scala/sqs4s/api/lo/DeleteMessageBatchItSpec.scala
+++ b/native/src/it/scala/sqs4s/api/lo/DeleteMessageBatchItSpec.scala
@@ -30,7 +30,10 @@ class DeleteMessageBatchItSpec extends IOSpec {
     } yield (client, cred)
     resources.use {
       case (client, cred) =>
-        DeleteMessageBatch[IO](Chunk(DeleteMessageBatch.Entry("1", "test")))
+        DeleteMessageBatch[IO](List(DeleteMessageBatch.Entry(
+          "1",
+          ReceiptHandle("test")
+        )))
           .runWith(
             client,
             SqsConfig(

--- a/native/src/it/scala/sqs4s/api/lo/DeleteMessageItSpec.scala
+++ b/native/src/it/scala/sqs4s/api/lo/DeleteMessageItSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration.TimeUnit
 class DeleteMessageItSpec extends IOSpec {
 
   val testCurrentMillis = 1586623258684L
-  val receiptHandle = "123456"
+  val receiptHandle = ReceiptHandle("123456")
 
   override implicit lazy val testClock: Clock[IO] = new Clock[IO] {
     def realTime(unit: TimeUnit): IO[Long] = IO.pure(testCurrentMillis)

--- a/native/src/main/scala/sqs4s/api/hi/SqsConsumer.scala
+++ b/native/src/main/scala/sqs4s/api/hi/SqsConsumer.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import fs2._
 import org.http4s.client.Client
 import sqs4s.api.errors.{DeleteMessageBatchErrors, RetriableServerError}
-import sqs4s.api.lo.{DeleteMessage, DeleteMessageBatch, ReceiveMessage}
+import sqs4s.api.lo._
 import sqs4s.api.{ConsumerConfig, ConsumerSettings, SqsConfig}
 import sqs4s.auth.Credentials
 import sqs4s.serialization.SqsDeserializer
@@ -16,27 +16,96 @@ import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
 trait SqsConsumer[F[_], T] {
+
+  /**
+    * Read messages from SQS queue as T, for each message, apply process
+    * `process` function and automatically acknowledge the message on completion
+    * of `process`.
+    *
+    * Suitable for FIFO and non-FIFO queue. The message is acknowledged one by
+    * one instead of batching.
+    */
   def consume(process: T => F[Unit]): F[Unit]
 
-  // not suitable for FIFO queue
-  def consumeAsync(maxConcurrent: Int, groupWithin: FiniteDuration = 1.second)(
+  /**
+    * Parallel read messages from SQS queue as a Stream of T, for each message,
+    * apply process `process` function and automatically acknowledge the
+    * messages in batch.
+    *
+    * NOTE: This is not suitable for FIFO queue because it reads messages in
+    * parallel so the order is lost.
+    */
+  def consumeAsync(
+    maxConcurrent: Int,
+    groupWithin: FiniteDuration = 500.millis
+  )(
     process: T => F[Unit]
   ): Stream[F, Unit]
 
+  /**
+    * Read messages from SQS queue as a Stream of T, automatically acknowledge
+    * messages BEFORE pushing T into the Stream.
+    *
+    * Suitable for FIFO and non-FIFO queue. The message is acknowledged one by
+    * one instead of batching.
+    */
   def dequeue: Stream[F, T]
 
-  // not suitable for FIFO queue
+  /**
+    * Parallel read messages from SQS queue as a Stream of T, automatically
+    * acknowledge messages BEFORE pushing T into the Stream.
+    *
+    * NOTE: This is not suitable for FIFO queue because it reads messages in
+    * parallel so the order is lost.
+    */
   def dequeueAsync(
     maxConcurrent: Int,
-    groupWithin: FiniteDuration = 1.second
+    groupWithin: FiniteDuration = 500.millis
   ): Stream[F, T]
 
+  /**
+    * Read N messages from the queue without acknowledge them.
+    */
   def peek(number: Int): Stream[F, T]
 
+  /**
+    * Similar to `peek` but return also a ReceiptHandle to manually acknowledge
+    * messages and return up to `maxRead` number of messages.
+    */
   def read: F[Chunk[ReceiveMessage.Result[T]]]
+
+  /**
+    * Similar to `read` but return a Stream of `ReceiveMessage.Result[T]` which
+    * can be used to manually acknowledge messages.
+    */
+  def reads: Stream[F, ReceiveMessage.Result[T]]
+
+  /**
+    * Similar to `reads` but read messages in parallel.
+    *
+    * NOTE: This is not suitable for FIFO queue because it reads messages in
+    * parallel so the order is lost.
+    */
+  def readsAsync(maxConcurrent: Int): Stream[F, ReceiveMessage.Result[T]]
+
+  /**
+    * Acknowledge that a message has been read.
+    */
+  def ack: Pipe[F, ReceiptHandle, Unit]
+
+  /**
+    * Batch acknowledge that messages has been read.
+    */
+  def batchAck(
+    maxConcurrent: Int,
+    groupWithin: FiniteDuration = 500.millis
+  ): Pipe[F, DeleteMessageBatch.Entry, Unit]
 }
 
 object SqsConsumer {
+
+  private val MaxBatchSize = 10
+
   def apply[T]: ApplyPartiallyApplied[T] =
     new ApplyPartiallyApplied(dummy = true)
 
@@ -86,47 +155,42 @@ object SqsConsumer {
           )
 
         override def consume(process: T => F[Unit]): F[Unit] = {
-          def ack: Pipe[F, Chunk[ReceiveMessage.Result[T]], Unit] =
-            input => {
-              val toAck = input.evalMap { chunk =>
-                chunk
-                  .parTraverse { entry =>
-                    process(entry.body).as(
-                      DeleteMessage[F](entry.receiptHandle)
-                    )
-                  }
-              }
-              toAck.flatMap { chunk =>
-                Stream.chunk[F, DeleteMessage[F]](chunk).flatMap { del =>
-                  retry(del.runWith(client, config).void)
-                }
+          def ack: Pipe[F, ReceiveMessage.Result[T], Unit] =
+            _.flatMap { entry =>
+              Stream.eval(process(entry.body)).flatMap { _ =>
+                retry(DeleteMessage[F](entry.receiptHandle).runWith(
+                  client,
+                  config
+                ).void)
               }
             }
 
-          Stream
-            .repeatEval(read)
-            .metered(consumerConfig.pollingRate)
-            .filter(_.nonEmpty)
-            .broadcastThrough(ack)
+          reads
+            .through(ack)
             .compile
             .drain
         }
 
         override def consumeAsync(
           maxConcurrent: Int,
-          groupWithin: FiniteDuration = 1.second
+          groupWithin: FiniteDuration = 500.millis
         )(process: T => F[Unit]): Stream[F, Unit] = {
           import DeleteMessageBatch._
 
           val ack: Pipe[F, Chunk[ReceiveMessage.Result[T]], Unit] =
-            _.mapAsync(maxConcurrent) { chunk => // chunk of up to 10 elems
-              chunk
+            _.flatMap { chunk => // chunk of up to 10 elems
+              val processed = chunk
                 .parTraverse { entry =>
                   process(entry.body)
                     .as(Entry(entry.messageId, entry.receiptHandle))
                 }
-                .flatMap { entries =>
-                  retry(DeleteMessageBatch[F](entries).runWith(
+              Stream.evalUnChunk(processed).groupWithin(
+                MaxBatchSize,
+                groupWithin
+              ).map {
+                entries =>
+                  val dedup = entries.toList.distinctBy(_.id)
+                  retry(DeleteMessageBatch[F](dedup).runWith(
                     client,
                     config
                   ))
@@ -139,52 +203,36 @@ object SqsConsumer {
                         case Nil => ().pure[F]
                       }
                     }
-                    .compile
-                    .lastOrError
-                }
+              }.parJoin(maxConcurrent)
             }
 
-          Stream
-            .constant[F, ReceiveMessage[F, T]](
-              ReceiveMessage[F, T](
-                consumerConfig.maxRead,
-                consumerConfig.visibilityTimeout,
-                consumerConfig.waitTimeSeconds
-              )
-            )
-            .metered(consumerConfig.pollingRate)
-            .mapAsync(maxConcurrent)(_.runWith(client, config))
-            .filter(_.nonEmpty)
-            .broadcastThrough(ack)
+          readsAsync(maxConcurrent)
+            .groupWithin(MaxBatchSize, groupWithin)
+            .through(ack)
         }
 
         override def dequeue: Stream[F, T] = {
-          val delete: Pipe[F, Chunk[ReceiveMessage.Result[T]], T] =
-            _.flatMap { res =>
-              Stream.chunk(res).flatMap { result =>
-                val r = DeleteMessage[F](result.receiptHandle)
-                  .runWith(client, config)
-                  .as(result.body)
-                Stream.eval(r)
-              }
+          val delete: Pipe[F, ReceiveMessage.Result[T], T] =
+            _.flatMap { entry =>
+              retry(DeleteMessage[F](entry.receiptHandle).runWith(
+                client,
+                config
+              ).as(entry.body))
             }
-          Stream
-            .repeatEval(read)
-            .metered(consumerConfig.pollingRate)
-            .filter(_.nonEmpty)
-            .broadcastThrough(delete)
+          reads
+            .through(delete)
         }
 
         override def dequeueAsync(
           maxConcurrent: Int,
-          groupWithin: FiniteDuration = 1.second
+          groupWithin: FiniteDuration = 500.millis
         ): Stream[F, T] = {
           val delete: Pipe[F, Chunk[ReceiveMessage.Result[T]], Chunk[T]] =
             _.mapAsync(maxConcurrent) { chunk =>
               val records = chunk.map(res => (res.messageId, res.body)).toList
               val entries = chunk.map { result =>
                 DeleteMessageBatch.Entry(result.messageId, result.receiptHandle)
-              }
+              }.toList.distinctBy(_.id)
               DeleteMessageBatch(entries).runWith(client, config).map {
                 deleted =>
                   val ids = deleted.successes.map(_.id)
@@ -194,18 +242,9 @@ object SqsConsumer {
               }
             }
 
-          Stream
-            .constant[F, ReceiveMessage[F, T]](
-              ReceiveMessage[F, T](
-                consumerConfig.maxRead,
-                consumerConfig.visibilityTimeout,
-                consumerConfig.waitTimeSeconds
-              )
-            )
-            .metered(consumerConfig.pollingRate)
-            .mapAsync(maxConcurrent)(_.runWith(client, config))
-            .filter(_.nonEmpty)
-            .broadcastThrough(delete)
+          readsAsync(maxConcurrent)
+            .groupWithin(MaxBatchSize, groupWithin)
+            .through(delete)
             .flatMap(Stream.chunk)
         }
 
@@ -224,7 +263,62 @@ object SqsConsumer {
             consumerConfig.waitTimeSeconds
           ).runWith(client, config)
 
-        private def retry[U](f: F[U]) =
+        override def reads: Stream[F, ReceiveMessage.Result[T]] =
+          Stream
+            .constant[F, ReceiveMessage[F, T]](
+              ReceiveMessage[F, T](
+                consumerConfig.maxRead,
+                consumerConfig.visibilityTimeout,
+                consumerConfig.waitTimeSeconds
+              )
+            )
+            .metered(consumerConfig.pollingRate)
+            .evalMap(_.runWith(client, config))
+            .filter(_.nonEmpty)
+            .flatMap(Stream.chunk)
+
+        override def readsAsync(maxConcurrent: Int)
+          : Stream[F, ReceiveMessage.Result[T]] =
+          Stream
+            .constant[F, ReceiveMessage[F, T]](
+              ReceiveMessage[F, T](
+                consumerConfig.maxRead,
+                consumerConfig.visibilityTimeout,
+                consumerConfig.waitTimeSeconds
+              )
+            )
+            .metered(consumerConfig.pollingRate)
+            .mapAsync(maxConcurrent)(_.runWith(client, config))
+            .filter(_.nonEmpty)
+            .flatMap(Stream.chunk)
+
+        override def ack: Pipe[F, ReceiptHandle, Unit] =
+          _.evalMap { handle =>
+            DeleteMessage[F](handle).runWith(client, config).void
+          }
+
+        override def batchAck(
+          maxConcurrent: Int,
+          groupWithin: FiniteDuration = 500.millis
+        ): Pipe[F, DeleteMessageBatch.Entry, Unit] =
+          _.groupWithin(MaxBatchSize, groupWithin).map { entries =>
+            val dedup = entries.toList.distinctBy(_.id)
+            retry(DeleteMessageBatch[F](dedup).runWith(
+              client,
+              config
+            ))
+              .evalMap { result =>
+                result.errors match {
+                  case head :: tail =>
+                    DeleteMessageBatchErrors(
+                      NonEmptyList.of(head, tail: _*)
+                    ).raiseError[F, Unit]
+                  case Nil => ().pure[F]
+                }
+              }
+          }.parJoin(maxConcurrent)
+
+        private def retry[U](f: F[U]): Stream[F, U] =
           Stream
             .retry[F, U](
               f,

--- a/native/src/main/scala/sqs4s/api/lo/Action.scala
+++ b/native/src/main/scala/sqs4s/api/lo/Action.scala
@@ -16,6 +16,8 @@ import scala.xml.{Elem, XML}
 
 abstract class Action[F[_]: Sync: Timer, T] {
 
+  val version = List("Version" -> "2012-11-05")
+
   @deprecated("use SqsConfig instead", "1.1.0")
   def runWith(client: Client[F], settings: SqsSettings): F[T] =
     mkRequest(settings)

--- a/native/src/main/scala/sqs4s/api/lo/CreateQueue.scala
+++ b/native/src/main/scala/sqs4s/api/lo/CreateQueue.scala
@@ -29,9 +29,8 @@ case class CreateQueue[F[_]: Sync: Clock: Timer](
 
     val queries = List(
       "Action" -> "CreateQueue",
-      "QueueName" -> name,
-      "Version" -> "2012-11-05"
-    )
+      "QueueName" -> name
+    ) ++ version
 
     val params =
       attributes.zipWithIndex

--- a/native/src/main/scala/sqs4s/api/lo/DeleteQueue.scala
+++ b/native/src/main/scala/sqs4s/api/lo/DeleteQueue.scala
@@ -2,36 +2,35 @@ package sqs4s.api.lo
 
 import cats.effect.{Clock, Sync, Timer}
 import cats.implicits._
-import org.http4s.Request
+import org.http4s.{Request, Uri}
 import sqs4s.api.SqsConfig
 import sqs4s.api.errors.UnexpectedResponseError
 
 import scala.xml.Elem
 
-case class DeleteMessage[F[_]: Sync: Clock: Timer](
-  receiptHandle: ReceiptHandle
-) extends Action[F, DeleteMessage.Result] {
+case class DeleteQueue[F[_]: Sync: Clock: Timer](
+  sqsEndpoint: Uri
+) extends Action[F, DeleteQueue.Result] {
 
   def mkRequest(config: SqsConfig[F]): F[Request[F]] = {
-    val params = List(
-      "Action" -> "DeleteMessage",
-      "ReceiptHandle" -> receiptHandle.value
+    val param = List(
+      "Action" -> "DeleteQueue"
     ) ++ version
 
-    SignedRequest.post[F](
-      params,
-      config.queue,
+    SignedRequest.get[F](
+      param,
+      sqsEndpoint,
       config.credentials,
       config.region
     ).render
   }
 
-  def parseResponse(response: Elem): F[DeleteMessage.Result] = {
+  def parseResponse(response: Elem): F[DeleteQueue.Result] = {
     val rid = (response \\ "RequestId").text
     rid.nonEmpty
       .guard[Option]
       .as {
-        DeleteMessage.Result(rid).pure[F]
+        DeleteQueue.Result(rid).pure[F]
       }
       .getOrElse {
         Sync[F].raiseError(UnexpectedResponseError("RequestId", response))
@@ -39,6 +38,6 @@ case class DeleteMessage[F[_]: Sync: Clock: Timer](
   }
 }
 
-object DeleteMessage {
+object DeleteQueue {
   case class Result(requestId: String)
 }

--- a/native/src/main/scala/sqs4s/api/lo/SendMessage.scala
+++ b/native/src/main/scala/sqs4s/api/lo/SendMessage.scala
@@ -23,9 +23,8 @@ case class SendMessage[F[_]: Sync: Clock: Timer, T](
     val params = {
       val queries = List(
         "Action" -> "SendMessage",
-        "MessageBody" -> serializer.serialize(message),
-        "Version" -> "2012-11-05"
-      ) ++ (
+        "MessageBody" -> serializer.serialize(message)
+      ) ++ version ++ (
         dedupId.map(ddid => List("MessageDeduplicationId" -> ddid)) |+|
           groupId.map(gid => List("MessageGroupId" -> gid)) |+|
           delay.map(d => List("DelaySeconds" -> d.toSeconds.toString))

--- a/native/src/main/scala/sqs4s/api/lo/SendMessageBatch.scala
+++ b/native/src/main/scala/sqs4s/api/lo/SendMessageBatch.scala
@@ -81,7 +81,7 @@ case class SendMessageBatch[F[_]: Sync: Clock: Timer, T](
 
   def mkRequest(config: SqsConfig[F]): F[Request[F]] = {
     val params =
-      List("Action" -> "SendMessageBatch", "Version" -> "2012-11-05") ++ entries
+      List("Action" -> "SendMessageBatch") ++ version ++ entries
 
     SignedRequest.post[F](
       params,

--- a/native/src/test/scala/sqs4s/api/lo/DeleteMessageBatchSpec.scala
+++ b/native/src/test/scala/sqs4s/api/lo/DeleteMessageBatchSpec.scala
@@ -7,7 +7,6 @@ import org.http4s.implicits._
 import sqs4s.IOSpec
 import sqs4s.api.errors.UnexpectedResponseError
 import sqs4s.api.{AwsAuth, SqsSettings}
-import sqs4s.serialization.instances._
 
 import scala.concurrent.duration._
 import scala.xml.XML
@@ -23,9 +22,9 @@ class DeleteMessageBatchSpec extends IOSpec {
     AwsAuth(accessKey, secretKey, "eu-west-1")
   )
   val attr = Map("foo" -> "1", "bar" -> "2")
-  val batch = Chunk(
-    DeleteMessageBatch.Entry("1", "test1"),
-    DeleteMessageBatch.Entry("2", "test2")
+  val batch = List(
+    DeleteMessageBatch.Entry("1", ReceiptHandle("test1")),
+    DeleteMessageBatch.Entry("2", ReceiptHandle("test2"))
   )
 
   override implicit lazy val testClock: Clock[IO] = new Clock[IO] {

--- a/native/src/test/scala/sqs4s/api/lo/DeleteMessageSpec.scala
+++ b/native/src/test/scala/sqs4s/api/lo/DeleteMessageSpec.scala
@@ -13,7 +13,7 @@ import scala.xml.XML
 class DeleteMessageSpec extends IOSpec {
 
   val testCurrentMillis = 1586623258684L
-  val receiptHandle = "123456"
+  val receiptHandle = ReceiptHandle("123456")
   val accessKey = "ACCESS_KEY"
   val secretKey = "SECRET_KEY"
   val settings = SqsSettings(

--- a/native/src/test/scala/sqs4s/internal/aws4/aws4suite/CanonicalRequestSpec.scala
+++ b/native/src/test/scala/sqs4s/internal/aws4/aws4suite/CanonicalRequestSpec.scala
@@ -51,10 +51,13 @@ class CanonicalRequestSpec extends IOSpec {
       uri = uri"/",
       headers = Headers.of(
         Header("Host", "example.amazonaws.com"),
-        Header("My-Header1", """value1
+        Header(
+          "My-Header1",
+          """value1
             |  value2
             |     value3
-          """.stripMargin),
+          """.stripMargin
+        ),
         Header(XAmzDate, testTimeStamp)
       )
     )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.13
+sbt.version = 1.4.2


### PR DESCRIPTION
- Fix DeleteMessageBatch bug which doesn't use `groupWithin` param
- Add new API for consuming messages to make it more flexible to get messages in a stream and more control over acknowledge messages