### PR TITLE
Add support for 'MessageAttributes' metadata

### DIFF
--- a/native/src/it/scala/sqs4s/api/hi/models.scala
+++ b/native/src/it/scala/sqs4s/api/hi/models.scala
@@ -31,11 +31,7 @@ object TestMessage {
     Arbitrary(gen)
   }
 
-  def arbStream(n: Long): Stream[IO, TestMessage] = {
-    val msg = arbTestMessage.arbitrary.sample.get
-    Stream
-      .random[IO]
-      .map(i => msg.copy(int = i))
-      .take(n)
-  }
+  def sample: TestMessage = arbTestMessage.arbitrary.sample.get
+
+  def arb(n: Int): List[TestMessage] = List.fill(n)(sample)
 }

--- a/native/src/main/scala/sqs4s/api/lo/ReceiveMessage.scala
+++ b/native/src/main/scala/sqs4s/api/lo/ReceiveMessage.scala
@@ -24,7 +24,7 @@ final case class ReceiveMessage[F[_]: Sync: Clock: Timer, T](
       "MaxNumberOfMessages" -> maxNumberOfMessages.toString,
       "VisibilityTimeout" -> visibilityTimeout.toString,
       "AttributeName" -> "All",
-      "MessageAttributeName" -> "All",
+      "MessageAttributeName" -> "All"
     ) ++ version ++ waitTimeSeconds.toList.map(sec =>
       "WaitTimeSeconds" -> sec.toString
     )
@@ -47,7 +47,9 @@ final case class ReceiveMessage[F[_]: Sync: Clock: Timer, T](
           .map(node => (node \ "Name").text -> (node \ "Value").text)
           .toMap
         val messageAttributes = (msg \ "MessageAttribute")
-          .map(node => (node \ "Name").text -> (node \ "Value").text)
+          .map(node =>
+            (node \ "Name").text -> (node \ "Value" \ "StringValue").text
+          )
           .toMap
         val mid = (msg \ "MessageId").text
         val handle = (msg \ "ReceiptHandle").text

--- a/native/src/main/scala/sqs4s/api/lo/ReceiveMessage.scala
+++ b/native/src/main/scala/sqs4s/api/lo/ReceiveMessage.scala
@@ -23,7 +23,8 @@ final case class ReceiveMessage[F[_]: Sync: Clock: Timer, T](
       "Action" -> "ReceiveMessage",
       "MaxNumberOfMessages" -> maxNumberOfMessages.toString,
       "VisibilityTimeout" -> visibilityTimeout.toString,
-      "AttributeName" -> "All"
+      "AttributeName" -> "All",
+      "MessageAttributeName" -> "All",
     ) ++ version ++ waitTimeSeconds.toList.map(sec =>
       "WaitTimeSeconds" -> sec.toString
     )
@@ -45,6 +46,9 @@ final case class ReceiveMessage[F[_]: Sync: Clock: Timer, T](
         val attributes = (msg \ "Attribute")
           .map(node => (node \ "Name").text -> (node \ "Value").text)
           .toMap
+        val messageAttributes = (msg \ "MessageAttribute")
+          .map(node => (node \ "Name").text -> (node \ "Value").text)
+          .toMap
         val mid = (msg \ "MessageId").text
         val handle = (msg \ "ReceiptHandle").text
         handle.nonEmpty
@@ -57,7 +61,8 @@ final case class ReceiveMessage[F[_]: Sync: Clock: Timer, T](
                 t,
                 raw,
                 md5Body,
-                attributes
+                attributes,
+                messageAttributes
               )
             }
           }
@@ -82,6 +87,7 @@ object ReceiveMessage {
     body: T,
     rawBody: String,
     md5OfBody: String,
-    attributes: Map[String, String]
+    attributes: Map[String, String],
+    messageAttributes: Map[String, String]
   )
 }

--- a/native/src/main/scala/sqs4s/api/lo/SendMessage.scala
+++ b/native/src/main/scala/sqs4s/api/lo/SendMessage.scala
@@ -36,7 +36,8 @@ final case class SendMessage[F[_]: Sync: Clock: Timer, T](
           case ((key, value), index) =>
             List(
               s"MessageAttribute.${index + 1}.Name" -> key,
-              s"MessageAttribute.${index + 1}.Value" -> value
+              s"MessageAttribute.${index + 1}.Value.StringValue" -> value,
+              s"MessageAttribute.${index + 1}.Value.DataType" -> "String" // TODO: support other DataType
             )
         } ++ queries
     }

--- a/native/src/main/scala/sqs4s/api/lo/SendMessageBatch.scala
+++ b/native/src/main/scala/sqs4s/api/lo/SendMessageBatch.scala
@@ -24,7 +24,8 @@ final case class SendMessageBatch[F[_]: Sync: Clock: Timer, T](
           case ((key, value), index) =>
             List(
               s"MessageAttribute.${index + 1}.Name" -> key,
-              s"MessageAttribute.${index + 1}.Value" -> value
+              s"MessageAttribute.${index + 1}.Value.StringValue" -> value,
+              s"MessageAttribute.${index + 1}.Value.DataType" -> "String" // TODO: support other DataType
             )
         }
       List(
@@ -116,7 +117,12 @@ final case class SendMessageBatch[F[_]: Sync: Clock: Timer, T](
 }
 
 object SendMessageBatch {
-  final case class Entry[T](
+  final case class BatchEntry[T](
+    message: T,
+    attributes: Map[String, String] = Map.empty
+  )
+
+  private[api] final case class Entry[T](
     id: String,
     message: T,
     attributes: Map[String, String] = Map.empty,

--- a/native/src/test/scala/sqs4s/IOSpec.scala
+++ b/native/src/test/scala/sqs4s/IOSpec.scala
@@ -2,17 +2,18 @@ package sqs4s
 
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDateTime, ZoneOffset}
-
 import cats.effect._
 import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration.TimeUnit
 
-trait IOSpec extends AnyFlatSpecLike with Matchers {
+trait IOSpec extends AnyFlatSpecLike with ScalaFutures with Matchers {
 
   val testTimeStamp = "20150830T123600Z"
   val testDateTime =
@@ -30,6 +31,8 @@ trait IOSpec extends AnyFlatSpecLike with Matchers {
       }
     def monotonic(unit: TimeUnit): IO[Long] = IO(0L)
   }
+  implicit val pc: PatienceConfig =
+    PatienceConfig(scaled(5.minutes), 500.millis)
 
   def arb[T](implicit arb: Arbitrary[T]) = arb.arbitrary.sample.get
 

--- a/native/src/test/scala/sqs4s/api/lo/ReceiveMessageSpec.scala
+++ b/native/src/test/scala/sqs4s/api/lo/ReceiveMessageSpec.scala
@@ -95,7 +95,9 @@ class ReceiveMessageSpec extends IOSpec {
       .unsafeRunSync()
 
     messages.size shouldEqual 1
-    messages.head.flatMap(_.messageAttributes.get("UserDefinedAttribute")) contains("UserDefinedValue")
+    messages.head.flatMap(
+      _.messageAttributes.get("UserDefinedAttribute")
+    ) contains ("UserDefinedValue")
   }
 
   it should "return empty list of response doesn't contain any message" in {

--- a/native/src/test/scala/sqs4s/api/lo/ReceiveMessageSpec.scala
+++ b/native/src/test/scala/sqs4s/api/lo/ReceiveMessageSpec.scala
@@ -48,7 +48,7 @@ class ReceiveMessageSpec extends IOSpec {
   }
 
   it should "parse successful response" in {
-    ReceiveMessage[IO, String]()
+    val messages = ReceiveMessage[IO, String]()
       .parseResponse {
         val stubbed =
           s"""
@@ -79,6 +79,10 @@ class ReceiveMessageSpec extends IOSpec {
            |        <Name>ApproximateFirstReceiveTimestamp</Name>
            |        <Value>1250700979248</Value>
            |      </Attribute>
+           |      <MessageAttribute>
+           |        <Name>UserDefinedAttribute</Name>
+           |        <Value>UserDefinedValue</Value>
+           |      </MessageAttribute>
            |    </Message>
            |  </ReceiveMessageResult>
            |  <ResponseMetadata>
@@ -89,7 +93,9 @@ class ReceiveMessageSpec extends IOSpec {
         XML.loadString(stubbed)
       }
       .unsafeRunSync()
-      .size shouldEqual 1
+
+    messages.size shouldEqual 1
+    messages.head.flatMap(_.messageAttributes.get("UserDefinedAttribute")) contains("UserDefinedValue")
   }
 
   it should "return empty list of response doesn't contain any message" in {

--- a/native/src/test/scala/sqs4s/api/lo/SendMessageBatchSpec.scala
+++ b/native/src/test/scala/sqs4s/api/lo/SendMessageBatchSpec.scala
@@ -66,25 +66,37 @@ class SendMessageBatchSpec extends IOSpec {
     params("SendMessageBatchRequestEntry.2.Id") shouldEqual "2"
     params("SendMessageBatchRequestEntry.1.MessageBody") shouldEqual "test1"
     params("SendMessageBatchRequestEntry.2.MessageBody") shouldEqual "test2"
+    params(
+      "SendMessageBatchRequestEntry.1.MessageAttribute.1.Value.DataType"
+    ) shouldEqual "String"
+    params(
+      "SendMessageBatchRequestEntry.1.MessageAttribute.2.Value.DataType"
+    ) shouldEqual "String"
+    params(
+      "SendMessageBatchRequestEntry.2.MessageAttribute.1.Value.DataType"
+    ) shouldEqual "String"
+    params(
+      "SendMessageBatchRequestEntry.2.MessageAttribute.2.Value.DataType"
+    ) shouldEqual "String"
     attr(
       params("SendMessageBatchRequestEntry.1.MessageAttribute.1.Name")
     ) shouldEqual params(
-      "SendMessageBatchRequestEntry.1.MessageAttribute.1.Value"
+      "SendMessageBatchRequestEntry.1.MessageAttribute.1.Value.StringValue"
     )
     attr(
       params("SendMessageBatchRequestEntry.1.MessageAttribute.2.Name")
     ) shouldEqual params(
-      "SendMessageBatchRequestEntry.1.MessageAttribute.2.Value"
+      "SendMessageBatchRequestEntry.1.MessageAttribute.2.Value.StringValue"
     )
     attr(
       params("SendMessageBatchRequestEntry.2.MessageAttribute.1.Name")
     ) shouldEqual params(
-      "SendMessageBatchRequestEntry.2.MessageAttribute.1.Value"
+      "SendMessageBatchRequestEntry.2.MessageAttribute.1.Value.StringValue"
     )
     attr(
       params("SendMessageBatchRequestEntry.2.MessageAttribute.2.Name")
     ) shouldEqual params(
-      "SendMessageBatchRequestEntry.2.MessageAttribute.2.Value"
+      "SendMessageBatchRequestEntry.2.MessageAttribute.2.Value.StringValue"
     )
     params("SendMessageBatchRequestEntry.1.DelaySeconds") shouldEqual "2"
     params("SendMessageBatchRequestEntry.2.DelaySeconds") shouldEqual "2"

--- a/native/src/test/scala/sqs4s/api/lo/SendMessageSpec.scala
+++ b/native/src/test/scala/sqs4s/api/lo/SendMessageSpec.scala
@@ -47,14 +47,16 @@ class SendMessageSpec extends IOSpec {
         .unsafeRunSync()
     val params = request.uri.query.params
     params("Action") shouldEqual "SendMessage"
-    params.get("Version").nonEmpty shouldEqual true
+    params.contains("Version") shouldEqual true
     params("DelaySeconds").toInt shouldEqual 2
     attr(params("MessageAttribute.1.Name")) shouldEqual params(
-      "MessageAttribute.1.Value"
+      "MessageAttribute.1.Value.StringValue"
     )
+    params("MessageAttribute.1.Value.DataType") shouldEqual "String"
     attr(params("MessageAttribute.2.Name")) shouldEqual params(
-      "MessageAttribute.2.Value"
+      "MessageAttribute.2.Value.StringValue"
     )
+    params("MessageAttribute.2.Value.DataType") shouldEqual "String"
     params("MessageBody") shouldEqual "test"
     params("MessageDeduplicationId") shouldEqual "dedup1"
     params("MessageGroupId") shouldEqual "group1"

--- a/native/src/test/scala/sqs4s/auth/CredentialsSpec.scala
+++ b/native/src/test/scala/sqs4s/auth/CredentialsSpec.scala
@@ -14,7 +14,7 @@ class CredentialsSpec extends IOSpec with Arbitraries {
 
   behavior.of("instanceMetadataResource")
 
-  def calledCounterMockClient(
+  private def calledCounterMockClient(
     ref: Ref[IO, Int],
     genCreds: Gen[List[CredentialResponse]]
   ) =


### PR DESCRIPTION
For our SQS queue usage, we make extended use of `MessageAttribute` key-value pairs (see [documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes)), to store our own defined message "metadata".

Currently, `sqs4s` only supports the AWS built-in `Attribute` key-value pairs. This PR adds support for the user defined pairs as well.

I have extended the simple case in `ReceiveMessageSpec.scala` to include a single message attribute, and check that it is parsed correctly.

Let me know if there is any other test or addition you'd like to see.