### PR TITLE
Fix STS Web Identity Token for EKS

### DIFF
--- a/native/src/main/scala/sqs4s/auth/Credentials.scala
+++ b/native/src/main/scala/sqs4s/auth/Credentials.scala
@@ -331,7 +331,6 @@ object Credentials {
         Map(
           "Action" -> "AssumeRoleWithWebIdentity",
           "DurationSeconds" -> ttl.toSeconds.toString,
-          "ProviderId" -> "www.amazon.com",
           "RoleSessionName" -> roleSessionName,
           "RoleArn" -> roleArn,
           "WebIdentityToken" -> webIdToken,

--- a/native/src/main/scala/sqs4s/auth/Credentials.scala
+++ b/native/src/main/scala/sqs4s/auth/Credentials.scala
@@ -122,7 +122,7 @@ object Credentials {
   def all[F[_]: Concurrent: ContextShift: Timer](
     client: Client[F],
     blocker: Blocker,
-    ttl: FiniteDuration = 6.hours,
+    ttl: FiniteDuration = 3600.seconds,
     refreshBefore: FiniteDuration = 5.minutes,
     allowRedirect: Boolean = true
   ): Resource[F, Credentials[F]] = {


### PR DESCRIPTION
This PR adds some required changes to make Web Identity Token authentication work for EKS. As per the documentation, the
`ProviderId` must **not** be given, when using it for an OpenID Connect Provider (which is what EKS uses to grant IAM roles to kubernetes service accounts).

From the docs:
> Specify this value only for OAuth 2.0 access tokens. Currently www.amazon.com and graph.facebook.com are the only supported identity providers for OAuth 2.0 access tokens. Do not include URL schemes and port numbers.
>
> Do not specify this value for OpenID Connect ID tokens.

In addition to this, testing revealed that the default 6 hour TTL would cause the authentication request to be rejected:

```xml
<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
  <Error>
    <Type>Sender</Type>
    <Code>ValidationError</Code>
    <Message>The requested DurationSeconds exceeds the MaxSessionDuration set for this role.</Message>
  </Error>
  <RequestId>8f46130a-e482-4e91-bf29-26e767eb65e3</RequestId>
</ErrorResponse>
```

To fix this, I have set the default TTL for the `all` method to be 1 hour (3600 seconds).